### PR TITLE
fix: enable npm OIDC detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Verify npm OIDC is available
+        run: |
+          test "$GITHUB_ACTIONS" = "true"
+          test -n "$ACTIONS_ID_TOKEN_REQUEST_URL"
+          test -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+
       - name: Release and Publish to npm
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: npx semantic-release
+        run: GITHUB_ACTIONS=true npx semantic-release


### PR DESCRIPTION
## Summary

- verify that the release job received GitHub's OIDC request variables before publishing
- force the GitHub Actions provider marker used by `@semantic-release/npm` to enter its OIDC token-exchange path

## Root cause

The release log skipped the plugin's GitHub Actions OIDC verification entirely and fell back to token authentication. The plugin only starts OIDC exchange after detecting `GITHUB_ACTIONS`.

## Validation

- YAML parsed successfully
- Prettier workflow check passed
- verified `GITHUB_ACTIONS=true` selects the GitHub Actions provider in `env-ci`
