### PR TITLE
fix: enable npm OIDC registry detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,13 +87,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Verify npm OIDC is available
-        run: |
-          test "$GITHUB_ACTIONS" = "true"
-          test -n "$ACTIONS_ID_TOKEN_REQUEST_URL"
-          test -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN"
-
       - name: Release and Publish to npm
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: GITHUB_ACTIONS=true npx semantic-release
+        run: npx semantic-release

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "url": "git+https://github.com/abejarano/ts-mongo-criteria.git"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org",
+    "registry": "https://registry.npmjs.org/",
     "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

- set the npm registry in `publishConfig` to its canonical trailing-slash URL
- remove the temporary GitHub Actions environment workaround

## Root cause

`@semantic-release/npm` only enters trusted publishing when the resolved registry is exactly `https://registry.npmjs.org/`. The package configuration used the same URL without the trailing slash, so the plugin skipped OIDC and requested `NPM_TOKEN`.

## Validation

- YAML parsed successfully
- Prettier workflow and package checks passed
- verified the semantic-release registry resolver returns `https://registry.npmjs.org/`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run test -- --runInBand`
