### PR TITLE
feat: support transactional reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ await MongoTransaction.run(async (tx) => {
   await userRepository.upsert(user, tx)
   await auditRepository.upsert(auditEntry, tx)
   await sessionRepository.delete({ userId: user.getId() }, undefined, tx)
+
+  // Reads can observe writes made earlier in this transaction.
+  const persistedUser = await userRepository.one({ id: user.getId() }, tx)
 })
 ```
 
@@ -232,8 +235,8 @@ async deactivateUser(id: string, tx: MongoTransaction): Promise<void> {
 
 MongoDB transactions require a replica set or a sharded cluster; standalone
 MongoDB instances do not support them. This initial API applies the transaction
-context only to `upsert`, `delete`, and protected `updateOne`; `one` and `list`
-remain regular reads.
+context to `upsert`, `delete`, protected `updateOne`, `one`, and `list`.
+Pass `tx` as the third argument to `list` after `fieldsToExclude`.
 
 **Your First Query in 30 Seconds:**
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -219,13 +219,15 @@ await MongoTransaction.run(async (tx) => {
   await userRepository.upsert(user, tx)
   await profileRepository.upsert(profile, tx)
   await invitationRepository.delete({ userId: user.getId() }, undefined, tx)
+
+  const persistedUser = await userRepository.one({ id: user.getId() }, tx)
 })
 ```
 
 An error from the callback rolls back all writes and is rethrown to the caller.
 MongoDB must run as a replica set or sharded cluster; standalone deployments do
-not support transactions. In this release, `one` and `list` do not receive the
-transaction context, so use the API for coordinated writes only.
+not support transactions. Pass `tx` to `one` to read through the same session,
+or as the third argument to `list` after `fieldsToExclude`.
 
 ## Basic Concepts
 

--- a/src/mongo/IRepository.ts
+++ b/src/mongo/IRepository.ts
@@ -4,9 +4,13 @@ import { DeleteOptions } from "mongodb"
 import { MongoTransaction } from "./MongoTransaction"
 
 export interface IRepository<T extends AggregateRoot> {
-  one(filter: object): Promise<T | null>
+  one(filter: object, transaction?: MongoTransaction): Promise<T | null>
 
-  list<D>(criteria: Criteria, fieldsToExclude?: string[]): Promise<Paginate<D>>
+  list<D>(
+    criteria: Criteria,
+    fieldsToExclude?: string[],
+    transaction?: MongoTransaction
+  ): Promise<Paginate<D>>
 
   upsert(entity: T, transaction?: MongoTransaction): Promise<void>
 

--- a/src/mongo/MongoRepository.ts
+++ b/src/mongo/MongoRepository.ts
@@ -26,9 +26,15 @@ export abstract class MongoRepository<T extends AggregateRoot> {
   abstract collectionName(): string
 
   /** Finds a single entity and hydrates it via the aggregate's fromPrimitives. */
-  public async one(filter: object): Promise<T | null> {
+  public async one(
+    filter: object,
+    transaction?: MongoTransaction
+  ): Promise<T | null> {
     const collection = await this.collection<T>()
-    const result = await collection.findOne(filter as any)
+    const session = MongoTransaction.sessionFor(transaction)
+    const result = session
+      ? await collection.findOne(filter as any, { session })
+      : await collection.findOne(filter as any)
 
     if (!result) {
       return null
@@ -51,10 +57,15 @@ export abstract class MongoRepository<T extends AggregateRoot> {
   /** Lists entities by criteria and returns a paginated response. */
   public async list<D>(
     criteria: Criteria,
-    fieldsToExclude: string[] = []
+    fieldsToExclude: string[] = [],
+    transaction?: MongoTransaction
   ): Promise<Paginate<D>> {
-    const documents = await this.searchByCriteria<D>(criteria, fieldsToExclude)
-    return this.paginate<D>(documents)
+    const documents = await this.searchByCriteria<D>(
+      criteria,
+      fieldsToExclude,
+      transaction
+    )
+    return this.paginate<D>(documents, transaction)
   }
 
   /**
@@ -143,16 +154,18 @@ export abstract class MongoRepository<T extends AggregateRoot> {
 
   private async searchByCriteria<D>(
     criteria: Criteria,
-    fieldsToExclude: string[] = []
+    fieldsToExclude: string[] = [],
+    transaction?: MongoTransaction
   ): Promise<D[]> {
     this.criteria = criteria
     this.query = this.criteriaConverter.convert(criteria)
 
     const collection = await this.collection()
+    const session = MongoTransaction.sessionFor(transaction)
 
     if (fieldsToExclude.length === 0) {
       const results = await collection
-        .find(this.query.filter as any, {})
+        .find(this.query.filter as any, session ? { session } : {})
         .sort(this.query.sort)
         .skip(this.query.skip)
         .limit(this.query.limit)
@@ -167,7 +180,10 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     })
 
     const results = await collection
-      .find(this.query.filter as any, { projection })
+      .find(
+        this.query.filter as any,
+        session ? { projection, session } : { projection }
+      )
       .sort(this.query.sort)
       .skip(this.query.skip)
       .limit(this.query.limit)
@@ -176,10 +192,15 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     return results.map(({ _id, ...rest }) => rest as D)
   }
 
-  private async paginate<T>(documents: T[]): Promise<Paginate<T>> {
+  private async paginate<T>(
+    documents: T[],
+    transaction?: MongoTransaction
+  ): Promise<Paginate<T>> {
     const collection = await this.collection()
-
-    const count = await collection.countDocuments(this.query.filter as any)
+    const session = MongoTransaction.sessionFor(transaction)
+    const count = session
+      ? await collection.countDocuments(this.query.filter as any, { session })
+      : await collection.countDocuments(this.query.filter as any)
 
     const limit = this.criteria?.limit || 10
     const currentPage = this.criteria?.currentPage || 1

--- a/tests/MongoRepository.test.ts
+++ b/tests/MongoRepository.test.ts
@@ -38,6 +38,7 @@ class TestEntity extends AggregateRoot {
 // Mock de MongoClientFactory
 jest.mock("../src/mongo/MongoClientFactory", () => {
   const mockCollection = {
+    findOne: jest.fn(),
     find: jest.fn().mockReturnThis(),
     sort: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
@@ -406,6 +407,50 @@ describe("MongoRepository", () => {
         { email: "john@test.com" },
         { $set: { name: "Jane" } },
         { upsert: true }
+      )
+    })
+
+    it("uses the transaction session for one, list, and pagination count", async () => {
+      const session = {
+        withTransaction: jest.fn(async (callback) => callback()),
+        endSession: jest.fn(),
+      }
+      ;(MongoClientFactory.createClient as jest.Mock).mockResolvedValue({
+        startSession: jest.fn().mockReturnValue(session),
+        db: jest.fn().mockReturnValue({
+          collection: jest.fn().mockReturnValue(mockCollection),
+        }),
+      })
+      mockCollection.findOne.mockResolvedValue({
+        _id: "507f1f77bcf86cd799439011",
+        id: "507f1f77bcf86cd799439011",
+        name: "John",
+        email: "john@test.com",
+        status: "active",
+      })
+      mockCollection.toArray.mockResolvedValue([])
+      mockCollection.countDocuments.mockResolvedValue(0)
+      const criteria = new Criteria(Filters.fromValues([]), Order.none(), 10, 1)
+
+      await MongoTransaction.run(async (transaction) => {
+        const found = await repository.one(
+          { email: "john@test.com" },
+          transaction
+        )
+        const listed = await repository.list(criteria, [], transaction)
+
+        expect(found).toBeInstanceOf(TestEntity)
+        expect(listed).toEqual({ nextPag: null, count: 0, results: [] })
+      })
+
+      expect(mockCollection.findOne).toHaveBeenCalledWith(
+        { email: "john@test.com" },
+        { session }
+      )
+      expect(mockCollection.find).toHaveBeenCalledWith({}, { session })
+      expect(mockCollection.countDocuments).toHaveBeenCalledWith(
+        {},
+        { session }
       )
     })
   })


### PR DESCRIPTION
## Summary

- allow `one(filter, tx)` to read through the active MongoDB transaction session
- allow `list(criteria, fieldsToExclude, tx)` to use the session for the query and pagination count
- update repository interfaces, documentation, and tests for read-your-writes behavior

## Validation

- `bun run typecheck`
- `bun run test -- --runInBand`
- `bun test`
- `bun run build`
