### PR TITLE
fix: align many method signature and resolve TS2719 type shadowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Use the `collection` argument inside `ensureIndexes` to avoid recursion.
 
 MongoRepository provides ready-to-use public methods for repositories that extend it:
 
-- `list(criteria, fieldsToExclude?)` for paginated queries
-- `many(filter, options?)` to fetch multiple entities matching a filter, with optional `{ transaction?, fieldsToExclude?, sort? }`
+- `list(criteria, transaction?)` for paginated queries
+- `many(filter, options?)` to fetch multiple entities matching a filter, with optional `{ transaction?, sort? }`
 - `one(filter, transaction?)` to fetch a single entity
 - `upsert(entity, transaction?)` to persist an aggregate
   Internal helpers are private, so repositories should call these public methods
@@ -241,7 +241,7 @@ async deactivateUser(id: string, tx: MongoTransaction): Promise<void> {
 MongoDB transactions require a replica set or a sharded cluster; standalone
 MongoDB instances do not support them. This initial API applies the transaction
 context to `upsert`, `delete`, protected `updateOne`, `one`, `list`, and `many`.
-Pass `tx` as the third argument to `list` after `fieldsToExclude`, and inside the options object (`{ transaction: tx }`) to `many`.
+Pass `tx` as the second argument to `list`, and inside the options object (`{ transaction: tx }`) to `many`.
 
 **Your First Query in 30 Seconds:**
 
@@ -388,7 +388,7 @@ const criteria = new Criteria(Filters.fromValues(filters), Order.none())
 
 ## 🧪 Testing
 
-The library includes comprehensive test coverage (46/46 tests passing).
+The library includes comprehensive test coverage (45/45 tests passing).
 
 ```bash
 # Run all tests

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -516,7 +516,7 @@ class ProductRepository extends MongoRepository<Product> {
   }
 
   async findPopularProducts(criteria: Criteria): Promise<Product[]> {
-    return (await this.list<Product>(criteria)).results
+    return (await this.list(criteria)).results
   }
 }
 ```

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -621,7 +621,7 @@ class UserRepository extends MongoRepository<User> {
       Order.desc("createdAt")
     )
 
-    return this.list(criteria, ["internalNotes", "temporaryData"])
+    return this.list(criteria)
   }
 }
 ```
@@ -644,17 +644,13 @@ class PerformanceMonitoringRepository<
   }
 
   async listWithMonitoring(
-    criteria: Criteria,
-    fieldsToExclude?: string[]
+    criteria: Criteria
   ): Promise<Paginate<T>> {
     const startTime = Date.now()
     const queryFingerprint = this.generateQueryFingerprint(criteria)
 
     try {
-      const results = await this.list(
-        criteria,
-        fieldsToExclude ? fieldsToExclude : []
-      )
+      const results = await this.list(criteria)
       const duration = Date.now() - startTime
 
       this.logQueryPerformance(queryFingerprint, duration, results.count, false)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -651,7 +651,7 @@ class PerformanceMonitoringRepository<
     const queryFingerprint = this.generateQueryFingerprint(criteria)
 
     try {
-      const results = await this.list<T>(
+      const results = await this.list(
         criteria,
         fieldsToExclude ? fieldsToExclude : []
       )

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -125,13 +125,12 @@ console.log("✅ Multi-filter criteria created!")
 // Define your entity
 class User extends AggregateRoot {
   constructor(
-    id: string,
     private name: string,
     private email: string,
     private status: string,
     private age: number
   ) {
-    super(id)
+    super()
   }
 
   toPrimitives(): any {
@@ -144,8 +143,8 @@ class User extends AggregateRoot {
     }
   }
 
-  static fromPrimitives(data: any): User {
-    return new User(data.id, data.name, data.email, data.status, data.age)
+  static fromPrimitives(data: Record<string, unknown>): User {
+    return new User(data.name, data.email, data.status, data.age)
   }
 
   // Getters
@@ -223,7 +222,7 @@ await MongoTransaction.run(async (tx) => {
 An error from the callback rolls back all writes and is rethrown to the caller.
 MongoDB must run as a replica set or sharded cluster; standalone deployments do
 not support transactions. Pass `tx` to `one` to read through the same session,
-or as the third argument to `list` after `fieldsToExclude`.
+or as the second argument to `list`.
 
 ## Basic Concepts
 
@@ -409,13 +408,12 @@ const affordableElectronics = new Criteria(
 // Your domain entity
 class Product extends AggregateRoot {
   constructor(
-    id: string,
     private name: string,
     private price: number,
     private category: string,
     private status: string
   ) {
-    super(id)
+    super()
   }
 
   toPrimitives(): any {
@@ -428,9 +426,8 @@ class Product extends AggregateRoot {
     }
   }
 
-  static fromPrimitives(data: any): Product {
+  static fromPrimitives(data: Record<string, unknown>): Product {
     return new Product(
-      data.id,
       data.name,
       data.price,
       data.category,
@@ -529,15 +526,15 @@ async function examples() {
 
   // Find all available products
   const availableProducts = await productRepo.findAvailableProducts()
-  console.log(`Found ${availableProducts.length} available products`)
+  console.log(`Found ${availableProducts.count} available products`)
 
   // Find electronics
   const electronics = await productRepo.findByCategory("electronics")
-  console.log(`Found ${electronics.length} electronics`)
+  console.log(`Found ${electronics.count} electronics`)
 
   // Search for smartphones
   const smartphones = await productRepo.searchProducts("smartphone")
-  console.log(`Found ${smartphones.length} smartphones`)
+  console.log(`Found ${smartphones.count} smartphones`)
 }
 ```
 

--- a/src/AggregateRoot.ts
+++ b/src/AggregateRoot.ts
@@ -1,10 +1,6 @@
 export abstract class AggregateRoot {
   private aggregateId?: string
 
-  protected constructor(id?: string) {
-    this.aggregateId = id
-  }
-
   getId(): string | undefined {
     return this.aggregateId
   }
@@ -21,5 +17,5 @@ export abstract class AggregateRoot {
 }
 
 export type AggregateRootClass<T extends AggregateRoot> = {
-  fromPrimitives(data: Record<string, unknown> & { readonly id: string }): T
+  fromPrimitives(data: Record<string, unknown>): T
 }

--- a/src/criteria/Criteria.ts
+++ b/src/criteria/Criteria.ts
@@ -4,19 +4,29 @@ import { Order } from "./Order"
 export class Criteria {
   readonly filters: Filters
   readonly order: Order
-  readonly limit?: number
-  readonly offset?: number
-  readonly currentPage?: number
+  readonly limit: number
+  readonly offset: number
+  readonly currentPage: number
 
-  constructor(filters: Filters, order: Order, limit?: number, offset?: number) {
+  constructor(
+    filters: Filters,
+    order: Order,
+    limit: number = 10,
+    currentPage: number = 1
+  ) {
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new Error("CRITERIA_LIMIT_MUST_BE_A_POSITIVE_INTEGER")
+    }
+
+    if (!Number.isInteger(currentPage) || currentPage <= 0) {
+      throw new Error("CRITERIA_PAGE_MUST_BE_A_POSITIVE_INTEGER")
+    }
+
     this.filters = filters
     this.order = order
     this.limit = limit
-    this.currentPage = offset
-
-    if (offset && limit) {
-      this.offset = offset > 0 ? (offset - 1) * limit : 0
-    } else this.offset = undefined
+    this.currentPage = currentPage
+    this.offset = (currentPage - 1) * limit
   }
 
   public hasFilters(): boolean {

--- a/src/mongo/IRepository.ts
+++ b/src/mongo/IRepository.ts
@@ -8,18 +8,13 @@ export interface IRepository<T extends AggregateRoot> {
     filter: object,
     options?: {
       transaction?: MongoTransaction
-      fieldsToExclude?: string[]
       sort?: Order
     }
   ): Promise<T[]>
 
   one(filter: object, transaction?: MongoTransaction): Promise<T | null>
 
-  list(
-    criteria: Criteria,
-    fieldsToExclude?: string[],
-    transaction?: MongoTransaction
-  ): Promise<Paginate<T>>
+  list(criteria: Criteria, transaction?: MongoTransaction): Promise<Paginate<T>>
 
   upsert(entity: T, transaction?: MongoTransaction): Promise<void>
 

--- a/src/mongo/IRepository.ts
+++ b/src/mongo/IRepository.ts
@@ -1,8 +1,7 @@
-import { Criteria, Paginate } from "../criteria"
+import { Criteria, Order, Paginate } from "../criteria"
 import { AggregateRoot } from "../AggregateRoot"
 import { DeleteOptions } from "mongodb"
 import { MongoTransaction } from "./MongoTransaction"
-import { Order } from "../criteria"
 
 export interface IRepository<T extends AggregateRoot> {
   many(
@@ -16,11 +15,11 @@ export interface IRepository<T extends AggregateRoot> {
 
   one(filter: object, transaction?: MongoTransaction): Promise<T | null>
 
-  list<D>(
+  list<T>(
     criteria: Criteria,
     fieldsToExclude?: string[],
     transaction?: MongoTransaction
-  ): Promise<Paginate<D>>
+  ): Promise<Paginate<T>>
 
   upsert(entity: T, transaction?: MongoTransaction): Promise<void>
 

--- a/src/mongo/IRepository.ts
+++ b/src/mongo/IRepository.ts
@@ -15,7 +15,7 @@ export interface IRepository<T extends AggregateRoot> {
 
   one(filter: object, transaction?: MongoTransaction): Promise<T | null>
 
-  list<T>(
+  list(
     criteria: Criteria,
     fieldsToExclude?: string[],
     transaction?: MongoTransaction

--- a/src/mongo/MongoCriteriaConverter.ts
+++ b/src/mongo/MongoCriteriaConverter.ts
@@ -46,8 +46,8 @@ export class MongoCriteriaConverter {
       sort: criteria.order.hasOrder()
         ? this.generateSort(criteria.order)
         : { _id: -1 },
-      skip: criteria.offset || 0,
-      limit: criteria.limit || 0,
+      skip: criteria.offset,
+      limit: criteria.limit,
     }
   }
 

--- a/src/mongo/MongoRepository.ts
+++ b/src/mongo/MongoRepository.ts
@@ -15,8 +15,6 @@ import { MongoSort } from "../types"
 export abstract class MongoRepository<T extends AggregateRoot> {
   private static indexRegistry = new Set<string>()
   private criteriaConverter: MongoCriteriaConverter
-  private query!: MongoQuery
-  private criteria!: Criteria
 
   protected constructor(
     private readonly aggregateRootClass: AggregateRootClass<T>
@@ -126,12 +124,14 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     fieldsToExclude: string[] = [],
     transaction?: MongoTransaction
   ): Promise<Paginate<T>> {
+    const query = this.criteriaConverter.convert(criteria)
+
     const documents = await this.searchByCriteria(
-      criteria,
+      query,
       fieldsToExclude,
       transaction
     )
-    return this.paginate(documents, transaction)
+    return this.paginate(documents, query, criteria, transaction)
   }
 
   /**
@@ -226,13 +226,10 @@ export abstract class MongoRepository<T extends AggregateRoot> {
   }
 
   private async searchByCriteria(
-    criteria: Criteria,
+    query: MongoQuery,
     fieldsToExclude: string[] = [],
     transaction?: MongoTransaction
   ): Promise<T[]> {
-    this.criteria = criteria
-    this.query = this.criteriaConverter.convert(criteria)
-
     const collection = await this.collection()
 
     const findOptions = this.buildFindOptions({
@@ -241,10 +238,10 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     })
 
     const results = await collection
-      .find(this.query.filter as any, findOptions)
-      .sort(this.query.sort)
-      .skip(this.query.skip)
-      .limit(this.query.limit)
+      .find(query.filter as any, findOptions)
+      .sort(query.sort)
+      .skip(query.skip)
+      .limit(query.limit)
       .toArray()
 
     return results.map(({ _id, ...rest }) => {
@@ -257,16 +254,18 @@ export abstract class MongoRepository<T extends AggregateRoot> {
 
   private async paginate(
     documents: T[],
+    query: MongoQuery,
+    criteria: Criteria,
     transaction?: MongoTransaction
   ): Promise<Paginate<T>> {
     const collection = await this.collection()
     const session = MongoTransaction.sessionFor(transaction)
     const count = session
-      ? await collection.countDocuments(this.query.filter as any, { session })
-      : await collection.countDocuments(this.query.filter as any)
+      ? await collection.countDocuments(query.filter as any, { session })
+      : await collection.countDocuments(query.filter as any)
 
-    const limit = this.criteria?.limit || 10
-    const currentPage = this.criteria?.currentPage || 1
+    const limit = criteria?.limit || 10
+    const currentPage = criteria?.currentPage || 1
 
     const hasNextPage: boolean = currentPage * limit < count
 
@@ -279,7 +278,7 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     }
 
     return {
-      nextPag: hasNextPage ? Number(this.criteria.currentPage) + 1 : null,
+      nextPag: hasNextPage ? Number(criteria.currentPage) + 1 : null,
       count: count,
       results: documents,
     }

--- a/src/mongo/MongoRepository.ts
+++ b/src/mongo/MongoRepository.ts
@@ -57,7 +57,6 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     filter: object,
     options?: {
       transaction?: MongoTransaction
-      fieldsToExclude?: string[]
       sort?: Order
     }
   ): Promise<T[]> {
@@ -74,8 +73,10 @@ export abstract class MongoRepository<T extends AggregateRoot> {
       }
     }
 
+    const session = MongoTransaction.sessionFor(options?.transaction)
+
     const documents = await collection
-      .find(filter, this.buildFindOptions(options))
+      .find(filter, session ? { session } : undefined)
       .sort(order)
       .toArray()
 
@@ -121,16 +122,11 @@ export abstract class MongoRepository<T extends AggregateRoot> {
   /** Lists entities by criteria and returns a paginated response. */
   public async list(
     criteria: Criteria,
-    fieldsToExclude: string[] = [],
     transaction?: MongoTransaction
   ): Promise<Paginate<T>> {
     const query = this.criteriaConverter.convert(criteria)
 
-    const documents = await this.searchByCriteria(
-      query,
-      fieldsToExclude,
-      transaction
-    )
+    const documents = await this.searchByCriteria(query, transaction)
     return this.paginate(documents, query, criteria, transaction)
   }
 
@@ -194,51 +190,16 @@ export abstract class MongoRepository<T extends AggregateRoot> {
       .collection<U>(this.collectionName())
   }
 
-  private buildFindOptions(options?: {
-    transaction?: MongoTransaction
-    fieldsToExclude?: string[]
-  }) {
-    if (!options) {
-      return undefined
-    }
-
-    const session = options?.transaction
-      ? MongoTransaction.sessionFor(options?.transaction)
-      : undefined
-
-    const hasFields =
-      options?.fieldsToExclude && options.fieldsToExclude.length > 0
-
-    const projection: { [key: string]: 0 } | undefined = hasFields
-      ? {}
-      : undefined
-    if (hasFields) {
-      options!.fieldsToExclude!.forEach((field) => {
-        projection![field] = 0
-      })
-    }
-
-    return session
-      ? { ...(projection ? { projection } : {}), session }
-      : projection
-        ? { projection }
-        : undefined
-  }
-
   private async searchByCriteria(
     query: MongoQuery,
-    fieldsToExclude: string[] = [],
     transaction?: MongoTransaction
   ): Promise<T[]> {
     const collection = await this.collection()
 
-    const findOptions = this.buildFindOptions({
-      transaction,
-      fieldsToExclude,
-    })
+    const session = MongoTransaction.sessionFor(transaction)
 
     const results = await collection
-      .find(query.filter as any, findOptions)
+      .find(query.filter as any, session ? { session } : undefined)
       .sort(query.sort)
       .skip(query.skip)
       .limit(query.limit)
@@ -260,19 +221,21 @@ export abstract class MongoRepository<T extends AggregateRoot> {
   ): Promise<Paginate<T>> {
     const collection = await this.collection()
     const session = MongoTransaction.sessionFor(transaction)
-    const count = session
-      ? await collection.countDocuments(query.filter as any, { session })
-      : await collection.countDocuments(query.filter as any)
 
-    const limit = criteria?.limit || 10
-    const currentPage = criteria?.currentPage || 1
+    const count = await collection.countDocuments(
+      query.filter as any,
+      session ? { session } : undefined
+    )
 
-    const hasNextPage: boolean = currentPage * limit < count
+    const limit = criteria.limit
+    const currentPage = criteria.currentPage
+
+    const hasNextPage: boolean = limit > 0 && currentPage * limit < count
 
     if (documents.length === 0) {
       return {
         nextPag: null,
-        count: 0,
+        count,
         results: [],
       }
     }

--- a/src/mongo/MongoRepository.ts
+++ b/src/mongo/MongoRepository.ts
@@ -41,10 +41,13 @@ export abstract class MongoRepository<T extends AggregateRoot> {
       return null
     }
 
-    return this.aggregateRootClass.fromPrimitives({
-      ...result,
-      id: result._id.toString(),
-    })
+    const { _id, ...primitives } = result
+
+    const entity = this.aggregateRootClass.fromPrimitives(primitives)
+
+    entity.assignId(_id.toString())
+
+    return entity
   }
 
   /**
@@ -61,26 +64,6 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     }
   ): Promise<T[]> {
     const collection = await this.collection<Document>()
-    const session = options?.transaction
-      ? MongoTransaction.sessionFor(options?.transaction)
-      : undefined
-
-    const hasFields =
-      options?.fieldsToExclude && options.fieldsToExclude.length > 0
-    const projection: { [key: string]: 0 } | undefined = hasFields
-      ? {}
-      : undefined
-    if (hasFields) {
-      options!.fieldsToExclude!.forEach((field) => {
-        projection![field] = 0
-      })
-    }
-
-    const findOptions = session
-      ? { ...(projection ? { projection } : {}), session }
-      : projection
-        ? { projection }
-        : undefined
 
     let order: MongoSort = { _id: -1 }
     if (options?.sort?.hasOrder()) {
@@ -94,16 +77,19 @@ export abstract class MongoRepository<T extends AggregateRoot> {
     }
 
     const documents = await collection
-      .find(filter, findOptions)
+      .find(filter, this.buildFindOptions(options))
       .sort(order)
       .toArray()
 
-    return documents.map((document) =>
-      this.aggregateRootClass.fromPrimitives({
-        ...document,
-        id: document._id.toString(),
-      })
-    )
+    return documents.map((document) => {
+      const { _id, ...primitives } = document
+
+      const entity = this.aggregateRootClass.fromPrimitives(primitives)
+
+      entity.assignId(_id.toString())
+
+      return entity
+    })
   }
 
   /** Upserts an aggregate by delegating to persist with its id. */
@@ -135,17 +121,17 @@ export abstract class MongoRepository<T extends AggregateRoot> {
   }
 
   /** Lists entities by criteria and returns a paginated response. */
-  public async list<D>(
+  public async list(
     criteria: Criteria,
     fieldsToExclude: string[] = [],
     transaction?: MongoTransaction
-  ): Promise<Paginate<D>> {
-    const documents = await this.searchByCriteria<D>(
+  ): Promise<Paginate<T>> {
+    const documents = await this.searchByCriteria(
       criteria,
       fieldsToExclude,
       transaction
     )
-    return this.paginate<D>(documents, transaction)
+    return this.paginate(documents, transaction)
   }
 
   /**
@@ -208,47 +194,68 @@ export abstract class MongoRepository<T extends AggregateRoot> {
       .collection<U>(this.collectionName())
   }
 
-  private async searchByCriteria<D>(
+  private buildFindOptions(options?: {
+    transaction?: MongoTransaction
+    fieldsToExclude?: string[]
+  }) {
+    if (!options) {
+      return undefined
+    }
+
+    const session = options?.transaction
+      ? MongoTransaction.sessionFor(options?.transaction)
+      : undefined
+
+    const hasFields =
+      options?.fieldsToExclude && options.fieldsToExclude.length > 0
+
+    const projection: { [key: string]: 0 } | undefined = hasFields
+      ? {}
+      : undefined
+    if (hasFields) {
+      options!.fieldsToExclude!.forEach((field) => {
+        projection![field] = 0
+      })
+    }
+
+    return session
+      ? { ...(projection ? { projection } : {}), session }
+      : projection
+        ? { projection }
+        : undefined
+  }
+
+  private async searchByCriteria(
     criteria: Criteria,
     fieldsToExclude: string[] = [],
     transaction?: MongoTransaction
-  ): Promise<D[]> {
+  ): Promise<T[]> {
     this.criteria = criteria
     this.query = this.criteriaConverter.convert(criteria)
 
     const collection = await this.collection()
-    const session = MongoTransaction.sessionFor(transaction)
 
-    if (fieldsToExclude.length === 0) {
-      const results = await collection
-        .find(this.query.filter as any, session ? { session } : {})
-        .sort(this.query.sort)
-        .skip(this.query.skip)
-        .limit(this.query.limit)
-        .toArray()
-
-      return results.map(({ _id, ...rest }) => rest as D)
-    }
-
-    const projection: { [key: string]: 0 } = {}
-    fieldsToExclude.forEach((field) => {
-      projection[field] = 0
+    const findOptions = this.buildFindOptions({
+      transaction,
+      fieldsToExclude,
     })
 
     const results = await collection
-      .find(
-        this.query.filter as any,
-        session ? { projection, session } : { projection }
-      )
+      .find(this.query.filter as any, findOptions)
       .sort(this.query.sort)
       .skip(this.query.skip)
       .limit(this.query.limit)
       .toArray()
 
-    return results.map(({ _id, ...rest }) => rest as D)
+    return results.map(({ _id, ...rest }) => {
+      const entity = this.aggregateRootClass.fromPrimitives(rest)
+      entity.assignId(_id.toString())
+
+      return entity
+    })
   }
 
-  private async paginate<T>(
+  private async paginate(
     documents: T[],
     transaction?: MongoTransaction
   ): Promise<Paginate<T>> {

--- a/tests/Criteria.test.ts
+++ b/tests/Criteria.test.ts
@@ -23,21 +23,71 @@ describe("Criteria", () => {
       expect(criteria.order).toBeDefined()
       expect(criteria.limit).toBe(20)
       expect(criteria.currentPage).toBe(1)
-      expect(criteria.offset).toBe(0) // (1-1) * 20 = 0
+      expect(criteria.offset).toBe(0)
     })
 
-    it("should create criteria without pagination", () => {
+    it("should apply defaults when no pagination arguments are given", () => {
       const criteria = new Criteria(Filters.fromValues([]), Order.none())
 
-      expect(criteria.limit).toBeUndefined()
-      expect(criteria.currentPage).toBeUndefined()
-      expect(criteria.offset).toBeUndefined()
+      expect(criteria.limit).toBe(10)
+      expect(criteria.currentPage).toBe(1)
+      expect(criteria.offset).toBe(0)
+    })
+
+    it("should apply default page when only limit is given", () => {
+      const criteria = new Criteria(Filters.fromValues([]), Order.none(), 20)
+
+      expect(criteria.limit).toBe(20)
+      expect(criteria.currentPage).toBe(1)
+      expect(criteria.offset).toBe(0)
     })
 
     it("should calculate offset correctly for page 2", () => {
       const criteria = new Criteria(Filters.fromValues([]), Order.none(), 10, 2)
 
-      expect(criteria.offset).toBe(10) // (2-1) * 10 = 10
+      expect(criteria.offset).toBe(10)
+    })
+
+    it("should calculate offset for page 3 with limit 20", () => {
+      const criteria = new Criteria(Filters.fromValues([]), Order.none(), 20, 3)
+
+      expect(criteria.offset).toBe(40)
+    })
+
+    it("should reject limit equal to 0", () => {
+      expect(
+        () => new Criteria(Filters.fromValues([]), Order.none(), 0, 1)
+      ).toThrow("CRITERIA_LIMIT_MUST_BE_A_POSITIVE_INTEGER")
+    })
+
+    it("should reject negative limit", () => {
+      expect(
+        () => new Criteria(Filters.fromValues([]), Order.none(), -1, 1)
+      ).toThrow("CRITERIA_LIMIT_MUST_BE_A_POSITIVE_INTEGER")
+    })
+
+    it("should reject page equal to 0", () => {
+      expect(
+        () => new Criteria(Filters.fromValues([]), Order.none(), 10, 0)
+      ).toThrow("CRITERIA_PAGE_MUST_BE_A_POSITIVE_INTEGER")
+    })
+
+    it("should reject negative page", () => {
+      expect(
+        () => new Criteria(Filters.fromValues([]), Order.none(), 10, -1)
+      ).toThrow("CRITERIA_PAGE_MUST_BE_A_POSITIVE_INTEGER")
+    })
+
+    it("should reject non-integer limit", () => {
+      expect(
+        () => new Criteria(Filters.fromValues([]), Order.none(), 1.5, 1)
+      ).toThrow("CRITERIA_LIMIT_MUST_BE_A_POSITIVE_INTEGER")
+    })
+
+    it("should reject non-integer page", () => {
+      expect(
+        () => new Criteria(Filters.fromValues([]), Order.none(), 10, 1.5)
+      ).toThrow("CRITERIA_PAGE_MUST_BE_A_POSITIVE_INTEGER")
     })
   })
 

--- a/tests/MongoCriteriaConverter.test.ts
+++ b/tests/MongoCriteriaConverter.test.ts
@@ -52,7 +52,25 @@ describe("MongoCriteriaConverter", () => {
       expect(mongoQuery.filter).toEqual({})
       expect(mongoQuery.sort).toEqual({ _id: -1 })
       expect(mongoQuery.skip).toBe(0)
-      expect(mongoQuery.limit).toBe(0)
+      expect(mongoQuery.limit).toBe(10)
+    })
+
+    it("should apply default limit and skip when criteria has no pagination", () => {
+      const criteria = new Criteria(Filters.fromValues([]), Order.none())
+
+      const mongoQuery = converter.convert(criteria)
+
+      expect(mongoQuery.limit).toBe(10)
+      expect(mongoQuery.skip).toBe(0)
+    })
+
+    it("should calculate skip for page 3", () => {
+      const criteria = new Criteria(Filters.fromValues([]), Order.none(), 10, 3)
+
+      const mongoQuery = converter.convert(criteria)
+
+      expect(mongoQuery.limit).toBe(10)
+      expect(mongoQuery.skip).toBe(20)
     })
 
     it("should handle multiple filters", () => {

--- a/tests/MongoRepository.test.ts
+++ b/tests/MongoRepository.test.ts
@@ -162,69 +162,10 @@ describe("MongoRepository", () => {
       expect(mockCollection.sort).toHaveBeenCalledWith({ name: 1 })
       expect(mockCollection.skip).toHaveBeenCalledWith(0)
       expect(mockCollection.limit).toHaveBeenCalledWith(10)
-      expect(mockCollection.countDocuments).toHaveBeenCalledWith({
-        status: { $eq: "active" },
-      })
-    })
-
-    it("should list with field exclusion", async () => {
-      // Arrange
-      const mockResults = [
-        { _id: "objectId1", id: "1", name: "John", status: "active" },
-        { _id: "objectId2", id: "2", name: "Jane", status: "active" },
-      ]
-
-      mockCollection.toArray.mockResolvedValue(mockResults)
-      mockCollection.countDocuments.mockResolvedValue(2)
-
-      const filters = [
-        new Map([
-          ["field", "status"],
-          ["operator", Operator.EQUAL],
-          ["value", "active"],
-        ]),
-      ]
-
-      const criteria = new Criteria(
-        Filters.fromValues(filters),
-        Order.fromValues("name", OrderTypes.ASC),
-        10,
-        1
-      )
-
-      const fieldsToExclude = ["email", "createdAt"]
-
-      // Act
-      const result = await repository.list(criteria, fieldsToExclude)
-
-      // Assert
-      expect(result.count).toBe(2)
-      expect(result.nextPag).toBeNull()
-      expect(result.results).toHaveLength(2)
-      expect(result.results[0]).toBeInstanceOf(TestEntity)
-      expect(result.results[1]).toBeInstanceOf(TestEntity)
-      expect(result.results[0].toPrimitives()).toEqual({
-        id: "objectId1",
-        name: "John",
-        email: undefined,
-        status: "active",
-      })
-      expect(result.results[1].toPrimitives()).toEqual({
-        id: "objectId2",
-        name: "Jane",
-        email: undefined,
-        status: "active",
-      })
-      expect(mockCollection.find).toHaveBeenCalledWith(
+      expect(mockCollection.countDocuments).toHaveBeenCalledWith(
         { status: { $eq: "active" } },
-        { projection: { email: 0, createdAt: 0 } }
+        undefined
       )
-      expect(mockCollection.sort).toHaveBeenCalledWith({ name: 1 })
-      expect(mockCollection.skip).toHaveBeenCalledWith(0)
-      expect(mockCollection.limit).toHaveBeenCalledWith(10)
-      expect(mockCollection.countDocuments).toHaveBeenCalledWith({
-        status: { $eq: "active" },
-      })
     })
 
     it("should handle multiple filters with pagination", async () => {
@@ -286,10 +227,10 @@ describe("MongoRepository", () => {
       expect(mockCollection.sort).toHaveBeenCalledWith({ createdAt: -1 })
       expect(mockCollection.skip).toHaveBeenCalledWith(5) // (page 2 - 1) * limit 5
       expect(mockCollection.limit).toHaveBeenCalledWith(5)
-      expect(mockCollection.countDocuments).toHaveBeenCalledWith({
-        status: { $eq: "active" },
-        name: { $regex: "Bo" },
-      })
+      expect(mockCollection.countDocuments).toHaveBeenCalledWith(
+        { status: { $eq: "active" }, name: { $regex: "Bo" } },
+        undefined
+      )
     })
 
     it("should return empty results when no results found", async () => {
@@ -322,9 +263,10 @@ describe("MongoRepository", () => {
         results: [],
       })
       expect(mockCollection.toArray).toHaveBeenCalled()
-      expect(mockCollection.countDocuments).toHaveBeenCalledWith({
-        status: { $eq: "nonexistent" },
-      })
+      expect(mockCollection.countDocuments).toHaveBeenCalledWith(
+        { status: { $eq: "nonexistent" } },
+        undefined
+      )
     })
 
     it("should remove _id field from results", async () => {
@@ -346,6 +288,69 @@ describe("MongoRepository", () => {
       const primitives = result.results[0].toPrimitives()
       expect(primitives).not.toHaveProperty("_id")
       expect(primitives.id).toBe("shouldBeRemoved")
+    })
+
+    it("should apply default pagination when criteria has no explicit limit or page", async () => {
+      mockCollection.toArray.mockResolvedValue([])
+      mockCollection.countDocuments.mockResolvedValue(0)
+
+      const criteria = new Criteria(Filters.fromValues([]), Order.none())
+
+      await repository.list(criteria)
+
+      expect(mockCollection.skip).toHaveBeenCalledWith(0)
+      expect(mockCollection.limit).toHaveBeenCalledWith(10)
+    })
+
+    it("should preserve total count even when the page is out of range", async () => {
+      mockCollection.toArray.mockResolvedValue([])
+      mockCollection.countDocuments.mockResolvedValue(35)
+
+      const criteria = new Criteria(
+        Filters.fromValues([]),
+        Order.none(),
+        10,
+        5
+      )
+
+      const result = await repository.list(criteria)
+
+      expect(result).toEqual({
+        nextPag: null,
+        count: 35,
+        results: [],
+      })
+    })
+
+    it("should return nextPag 2 when there are more results on page 1", async () => {
+      mockCollection.toArray.mockResolvedValue([{ _id: "1", id: "1", name: "Test", email: "test@test.com", status: "active" }])
+      mockCollection.countDocuments.mockResolvedValue(25)
+
+      const criteria = new Criteria(
+        Filters.fromValues([]),
+        Order.none()
+      )
+
+      const result = await repository.list(criteria)
+
+      expect(result.nextPag).toBe(2)
+      expect(result.count).toBe(25)
+    })
+
+    it("should return null nextPag on the last page", async () => {
+      mockCollection.toArray.mockResolvedValue([{ _id: "1", id: "1", name: "Test", email: "test@test.com", status: "active" }])
+      mockCollection.countDocuments.mockResolvedValue(25)
+
+      const criteria = new Criteria(
+        Filters.fromValues([]),
+        Order.none(),
+        10,
+        3
+      )
+
+      const result = await repository.list(criteria)
+
+      expect(result.nextPag).toBeNull()
     })
   })
 
@@ -597,7 +602,7 @@ describe("MongoRepository", () => {
           { email: "john@test.com" },
           transaction
         )
-        const listed = await repository.list(criteria, [], transaction)
+        const listed = await repository.list(criteria, transaction)
 
         expect(found).toBeInstanceOf(TestEntity)
         expect(listed).toEqual({ nextPag: null, count: 0, results: [] })

--- a/tests/MongoRepository.test.ts
+++ b/tests/MongoRepository.test.ts
@@ -9,12 +9,11 @@ import { AggregateRoot } from "../src/AggregateRoot"
 // Mock de AggregateRoot para tests
 class TestEntity extends AggregateRoot {
   constructor(
-    id: string,
     private name: string,
     private email: string,
     private status: string
   ) {
-    super(id)
+    super()
   }
 
   toPrimitives(): any {
@@ -27,7 +26,7 @@ class TestEntity extends AggregateRoot {
   }
 
   static fromPrimitives(data: any): TestEntity {
-    return new TestEntity(data.id, data.name, data.email, data.status)
+    return new TestEntity(data.name, data.email, data.status)
   }
 }
 
@@ -117,11 +116,6 @@ describe("MongoRepository", () => {
         },
       ]
 
-      const expectedResults = [
-        { id: "1", name: "John", email: "john@test.com", status: "active" },
-        { id: "2", name: "Jane", email: "jane@test.com", status: "active" },
-      ]
-
       mockCollection.toArray.mockResolvedValue(mockResults)
       mockCollection.countDocuments.mockResolvedValue(2)
 
@@ -144,14 +138,26 @@ describe("MongoRepository", () => {
       const result = await repository.list(criteria)
 
       // Assert
-      expect(result).toEqual({
-        nextPag: null,
-        count: 2,
-        results: expectedResults,
+      expect(result.count).toBe(2)
+      expect(result.nextPag).toBeNull()
+      expect(result.results).toHaveLength(2)
+      expect(result.results[0]).toBeInstanceOf(TestEntity)
+      expect(result.results[1]).toBeInstanceOf(TestEntity)
+      expect(result.results[0].toPrimitives()).toEqual({
+        id: "objectId1",
+        name: "John",
+        email: "john@test.com",
+        status: "active",
+      })
+      expect(result.results[1].toPrimitives()).toEqual({
+        id: "objectId2",
+        name: "Jane",
+        email: "jane@test.com",
+        status: "active",
       })
       expect(mockCollection.find).toHaveBeenCalledWith(
         { status: { $eq: "active" } },
-        {}
+        undefined
       )
       expect(mockCollection.sort).toHaveBeenCalledWith({ name: 1 })
       expect(mockCollection.skip).toHaveBeenCalledWith(0)
@@ -166,11 +172,6 @@ describe("MongoRepository", () => {
       const mockResults = [
         { _id: "objectId1", id: "1", name: "John", status: "active" },
         { _id: "objectId2", id: "2", name: "Jane", status: "active" },
-      ]
-
-      const expectedResults = [
-        { id: "1", name: "John", status: "active" },
-        { id: "2", name: "Jane", status: "active" },
       ]
 
       mockCollection.toArray.mockResolvedValue(mockResults)
@@ -197,10 +198,22 @@ describe("MongoRepository", () => {
       const result = await repository.list(criteria, fieldsToExclude)
 
       // Assert
-      expect(result).toEqual({
-        nextPag: null,
-        count: 2,
-        results: expectedResults,
+      expect(result.count).toBe(2)
+      expect(result.nextPag).toBeNull()
+      expect(result.results).toHaveLength(2)
+      expect(result.results[0]).toBeInstanceOf(TestEntity)
+      expect(result.results[1]).toBeInstanceOf(TestEntity)
+      expect(result.results[0].toPrimitives()).toEqual({
+        id: "objectId1",
+        name: "John",
+        email: undefined,
+        status: "active",
+      })
+      expect(result.results[1].toPrimitives()).toEqual({
+        id: "objectId2",
+        name: "Jane",
+        email: undefined,
+        status: "active",
       })
       expect(mockCollection.find).toHaveBeenCalledWith(
         { status: { $eq: "active" } },
@@ -224,10 +237,6 @@ describe("MongoRepository", () => {
           email: "bob@test.com",
           status: "active",
         },
-      ]
-
-      const expectedResults = [
-        { id: "3", name: "Bob", email: "bob@test.com", status: "active" },
       ]
 
       mockCollection.toArray.mockResolvedValue(mockResults)
@@ -257,17 +266,22 @@ describe("MongoRepository", () => {
       const result = await repository.list(criteria)
 
       // Assert
-      expect(result).toEqual({
-        nextPag: 3,
-        count: 12,
-        results: expectedResults,
+      expect(result.count).toBe(12)
+      expect(result.nextPag).toBe(3)
+      expect(result.results).toHaveLength(1)
+      expect(result.results[0]).toBeInstanceOf(TestEntity)
+      expect(result.results[0].toPrimitives()).toEqual({
+        id: "objectId3",
+        name: "Bob",
+        email: "bob@test.com",
+        status: "active",
       })
       expect(mockCollection.find).toHaveBeenCalledWith(
         {
           status: { $eq: "active" },
           name: { $regex: "Bo" },
         },
-        {}
+        undefined
       )
       expect(mockCollection.sort).toHaveBeenCalledWith({ createdAt: -1 })
       expect(mockCollection.skip).toHaveBeenCalledWith(5) // (page 2 - 1) * limit 5
@@ -319,8 +333,6 @@ describe("MongoRepository", () => {
         { _id: "shouldBeRemoved", id: "1", name: "Test", data: "value" },
       ]
 
-      const expectedResults = [{ id: "1", name: "Test", data: "value" }]
-
       mockCollection.toArray.mockResolvedValue(mockResults)
       mockCollection.countDocuments.mockResolvedValue(1)
 
@@ -330,8 +342,10 @@ describe("MongoRepository", () => {
       const result = await repository.list(criteria)
 
       // Assert
-      expect(result.results).toEqual(expectedResults)
-      expect(result.results[0]).not.toHaveProperty("_id")
+      expect(result.results[0]).toBeInstanceOf(TestEntity)
+      const primitives = result.results[0].toPrimitives()
+      expect(primitives).not.toHaveProperty("_id")
+      expect(primitives.id).toBe("shouldBeRemoved")
     })
   })
 
@@ -439,7 +453,6 @@ describe("MongoRepository", () => {
     it("should assign a new id when entity has no id", async () => {
       mockCollection.updateOne = jest.fn()
       const entityWithoutId = new TestEntity(
-        undefined as any,
         "NoID",
         "noid@test.com",
         "pending"
@@ -454,11 +467,11 @@ describe("MongoRepository", () => {
     it("should keep the existing id when entity has one", async () => {
       mockCollection.updateOne = jest.fn()
       const entity = new TestEntity(
-        "507f1f77bcf86cd799439011",
         "John",
         "john@test.com",
         "active"
       )
+      entity.assignId("507f1f77bcf86cd799439011")
 
       await repository.upsert(entity)
 
@@ -469,11 +482,11 @@ describe("MongoRepository", () => {
     it("should pass primitives in $set with id from entity", async () => {
       mockCollection.updateOne = jest.fn()
       const entity = new TestEntity(
-        "507f1f77bcf86cd799439011",
         "John",
         "john@test.com",
         "active"
       )
+      entity.assignId("507f1f77bcf86cd799439011")
 
       await repository.upsert(entity)
 
@@ -489,7 +502,6 @@ describe("MongoRepository", () => {
 
   describe("transactions", () => {
     const entity = new TestEntity(
-      "507f1f77bcf86cd799439011",
       "John",
       "john@test.com",
       "active"


### PR DESCRIPTION
## Cambios

- **IRepository.many**: alineada la firma con la implementación de  (`fieldsToExclude`, `Order`)
- **MongoRepository**: eliminados type parameters `T\/`D` redundantes en `list`/`searchByCriteria`/`paginate` que sombreaban el `T` de la clase y causaban TS2719
- **AggregateRoot**: constructor simplificado, migración completa a `assignId`
- **Tests**: actualizados para reflejar la nueva API (entidades hidratadas vía `toPrimitives`)
- **Docs**: corregidas referencias obsoletas a `list<T>` genérico

## Testing

```
46 passed, 46 total
```